### PR TITLE
Redirect user to requested page after login or silentAuth

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -34,6 +34,7 @@ export const login = () => {
     return
   }
 
+  if(window.localStorage.getItem("requestPath") === null) window.localStorage.setItem("requestPath", window.location.pathname)
   auth.authorize()
 }
 
@@ -51,13 +52,20 @@ const setSession = (cb = () => {}) => (err, authResult) => {
     tokens.expiresAt = expiresAt
     user = authResult.idTokenPayload
     localStorage.setItem("isLoggedIn", true)
-    navigate("/account")
+    let requestPath = window.localStorage.getItem("requestPath")
+    if(requestPath) {
+      window.localStorage.removeItem("requestPath")
+      navigate(requestPath)
+    }
     cb()
   }
 }
 
 export const silentAuth = callback => {
-  if (!isAuthenticated()) return callback()
+  if (!isAuthenticated()) {
+    return callback()
+  }
+  if(window.localStorage.getItem("requestPath") === null) window.localStorage.setItem("requestPath", window.location.pathname)
   auth.checkSession({}, setSession(callback))
 }
 


### PR DESCRIPTION
After a user logs in or is silently reauthenticated, they are taken to the accounts home page, even if the initial request was for the billing page. This PR fixes that by storing the first requested URI that causes an authentication event, and redirecting the user there instead.